### PR TITLE
Add initial Airtable search to Contribute.vue

### DIFF
--- a/ally-guide/.env.local.template
+++ b/ally-guide/.env.local.template
@@ -1,0 +1,8 @@
+# Go to https://airtable.com/account to get your API key
+# TODO: Is using VUE_APP_ sufficiently safe for our secrets? What would be safer?
+# See https://cli.vuejs.org/guide/mode-and-env.html#environment-variables
+VUE_APP_AIRTABLE_API_KEY=
+
+# Go to https://airtable.com/api, select the ally-guide base you want to use for testing,
+# The ID for the base will be in the Introduction section of the API docs.
+VUE_APP_AIRTABLE_BASE=

--- a/ally-guide/README.md
+++ b/ally-guide/README.md
@@ -5,6 +5,14 @@
 npm install
 ```
 
+### Configuration
+
+```
+cp .env.local.template .env.local
+```
+
+Edit `.env.local` and assign values to `VUE_APP_AIRTABLE_API_KEY` and `VUE_APP_AIRTABLE_BASE`
+
 ### Compiles and hot-reloads for development
 ```
 npm run serve


### PR DESCRIPTION
* Only searches the Distribute table by `Name` and `State` currently
* State abbreviations not supported
* No table presentation or styling done yet

- [ ] See if there's a way to pass the user input as a separate parameter to be embedded in the airtable "formula" to avoid something similar to a sql injection.

Part of https://github.com/Ally-Guide/ally-guide-app/issues/14

Open questions:
* Is using a `VUE_APP_` environment variable sufficiently safe for our secrets, given that they'll probably show up in the developer console regardless of what we do? What can we do that would be safer? See https://cli.vuejs.org/guide/mode-and-env.html#environment-variables

### Prompt
![image](https://user-images.githubusercontent.com/7145717/85096019-15c11000-b1c1-11ea-8e14-ec9e9a6e7cb0.png)

### Results
![image](https://user-images.githubusercontent.com/7145717/85096041-21acd200-b1c1-11ea-9bf2-7c14f246b48e.png)
