### PR TITLE
Sanitize user input before searching Airtable

### DIFF
--- a/ally-guide/src/views/Contribute.vue
+++ b/ally-guide/src/views/Contribute.vue
@@ -133,10 +133,16 @@ export default {
         }
       }
 
+      // Remove backslashes and double quotes from the user input to avoid injection. These characters aren't treated
+      // as literals by airtable. See https://support.airtable.com/hc/en-us/articles/203255215-Formula-Field-Reference#text
+      // I don't see a way in Airtable's API to have a prepared statement ("formula") and bind parameters to it.
+      // So we'll have to make due with sanitizing our inputs.
+      const searchText = this.search.replace(/[\\"]/g, '');
+
       // search the Distribute table by Name and State fields, case-insensitively.
       base('Distribute').select({
         view: "Grid view",
-        filterByFormula: `OR(FIND(LOWER("${this.search}"), LOWER({Name})), FIND(LOWER("${this.search}"), LOWER({State})))`,
+        filterByFormula: `OR(FIND(LOWER("${searchText}"), LOWER({Name})), FIND(LOWER("${searchText}"), LOWER({State})))`,
       }).eachPage(page.bind(this), done.bind(this));
     }
   },


### PR DESCRIPTION
I don't see a way to bind parameters to a prepared statement ("formula" in Airtable-speak), so we'll have to settle for sanitizing to avoid injections.

A sql-like injection is probably limited only to Airtable search. For inserting new records, we don't need to concatenate our code and user text. However for inserts we'll still need to check for script injection - user input like `Bail Fund<script>document.location = "https://badsite.com"</script>`

### Before

![image](https://user-images.githubusercontent.com/7145717/85159929-20fd5580-b22c-11ea-811e-2a37cffa349a.png)

### After

![image](https://user-images.githubusercontent.com/7145717/85159944-278bcd00-b22c-11ea-8bba-73e2afccbfa6.png)